### PR TITLE
Cart and account and metabox examples

### DIFF
--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -109,6 +109,7 @@
       "description": "Description",
       "on_sale": "Sale",
       "product_variants": "Product variants",
+      "pdf_file": "Download PDF",
       "media": {
         "gallery_viewer": "Gallery Viewer",
         "load_image": "Load image {{ index }} in gallery view",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -391,7 +391,8 @@
       "last_name": "Last name",
       "email": "Email",
       "password": "Password",
-      "submit": "Create"
+      "submit": "Create",
+      "email_consent": "Subscribe to email marketing. You can unsubscribe at any time!"
     },
     "reset_password": {
       "title": "Reset account password",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -199,7 +199,8 @@
       "search_for": "Search for “{{ terms }}”"
     },
     "cart": {
-      "cart": "Cart"
+      "cart": "Cart",
+      "gift_wrap": "I would like my purchase gift wrapped"
     },
     "contact": {
       "form": {

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -289,6 +289,9 @@
       </div>
     </div>
 
+    <input id="gift-wrapping" type="checkbox" name="attributes[gift-wrap]" value="yes">
+    <label for="gift-wrapping">I would like my purchase gift wrapped</label>
+
     <p class="visually-hidden" id="cart-live-region-text" aria-live="polite" role="status"></p>
     <p class="visually-hidden" id="shopping-cart-line-item-status" aria-live="polite" aria-hidden="true" role="status">{{ 'accessibility.loading' | t }}</p>
   </form>

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -290,7 +290,9 @@
     </div>
 
     <input id="gift-wrapping" type="checkbox" name="attributes[gift-wrap]" value="yes">
-    <label for="gift-wrapping">I would like my purchase gift wrapped</label>
+    <label for="gift-wrapping">{{ 'templates.cart.gift_wrap' | t }}</label>
+
+    {% render 'delivery-date' %}
 
     <p class="visually-hidden" id="cart-live-region-text" aria-live="polite" role="status"></p>
     <p class="visually-hidden" id="shopping-cart-line-item-status" aria-live="polite" aria-hidden="true" role="status">{{ 'accessibility.loading' | t }}</p>

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -220,6 +220,13 @@
                 {{ form | payment_terms }}
               {%- endform -%}
             </div>
+
+          {% if product.metafields.files.file_downloader != blank %}
+            <a href="{{ product.metafields.files.file_downloader | file_url  }}" download target="_blank">
+             {{ 'products.product.pdf_file' | t}}
+            </a>
+          {% endif %}
+
           {%- when 'description' -%}
             {%- if product.description != blank -%}
               <div class="product__description rte">

--- a/sections/newsletter.liquid
+++ b/sections/newsletter.liquid
@@ -36,7 +36,7 @@
                     type="email"
                     name="contact[email]"
                     class="field__input"
-                    value="{{ form.email }}"
+                    value="{% if customer %}{{ customer.name }}{% else %}{{ form.email }}{% endif %}"
                     aria-required="true"
                     autocorrect="off"
                     autocapitalize="off"

--- a/sections/newsletter.liquid
+++ b/sections/newsletter.liquid
@@ -36,7 +36,7 @@
                     type="email"
                     name="contact[email]"
                     class="field__input"
-                    value="{% if customer %}{{ customer.name }}{% else %}{{ form.email }}{% endif %}"
+                    value="{% if customer %}{{ customer.email }}{% else %}{{ form.email }}{% endif %}"
                     aria-required="true"
                     autocorrect="off"
                     autocapitalize="off"

--- a/snippets/delivery-date.liquid
+++ b/snippets/delivery-date.liquid
@@ -1,0 +1,27 @@
+{{ '//code.jquery.com/ui/1.9.2/themes/base/jquery-ui.css' | stylesheet_tag }}
+{{ '//ajax.googleapis.com/ajax/libs/jquery/2.2.3/jquery.min.js' | script_tag }}
+<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js" defer="defer"></script>
+
+<div style="width:300px; clear:both;">
+  <p>
+    <label for="date">Pick a delivery date:</label>
+    <input id="date" type="text" name="attributes[date]" value="{{ cart.attributes.date }}" />
+    <span style="display:block" class="instructions"> We do not deliver during the week-end.</span>
+  </p>
+</div>
+
+<script>
+  window.onload = function() {
+      if (window.jQuery) {
+        let $ = window.jQuery;
+
+        $(function() {
+          $("#date").datepicker({
+          minDate: +1,
+          maxDate: '+2M',
+          beforeShowDay: $.datepicker.noWeekends
+        });
+      });
+    }
+  }
+</script>

--- a/templates/customers/register.liquid
+++ b/templates/customers/register.liquid
@@ -1,120 +1,87 @@
 {{ 'customer.css' | asset_url | stylesheet_tag }}
 
 <div class="customer register">
-  <svg style="display: none">
-    <symbol id="icon-error" viewBox="0 0 13 13">
-      <circle cx="6.5" cy="6.50049" r="5.5" stroke="white" stroke-width="2"/>
-      <circle cx="6.5" cy="6.5" r="5.5" fill="#EB001B" stroke="#EB001B" stroke-width="0.7"/>
-      <path d="M5.87413 3.52832L5.97439 7.57216H7.02713L7.12739 3.52832H5.87413ZM6.50076 9.66091C6.88091 9.66091 7.18169 9.37267 7.18169 9.00504C7.18169 8.63742 6.88091 8.34917 6.50076 8.34917C6.12061 8.34917 5.81982 8.63742 5.81982 9.00504C5.81982 9.37267 6.12061 9.66091 6.50076 9.66091Z" fill="white"/>
-      <path d="M5.87413 3.17832H5.51535L5.52424 3.537L5.6245 7.58083L5.63296 7.92216H5.97439H7.02713H7.36856L7.37702 7.58083L7.47728 3.537L7.48617 3.17832H7.12739H5.87413ZM6.50076 10.0109C7.06121 10.0109 7.5317 9.57872 7.5317 9.00504C7.5317 8.43137 7.06121 7.99918 6.50076 7.99918C5.94031 7.99918 5.46982 8.43137 5.46982 9.00504C5.46982 9.57872 5.94031 10.0109 6.50076 10.0109Z" fill="white" stroke="#EB001B" stroke-width="0.7">
-    </symbol>
-  </svg>
-  <h1>
-    {{ 'customer.register.title' | t }}
-  </h1>
-  {%- form 'create_customer', novalidate: 'novalidate' -%}
-    {%- if form.errors -%}
-      <h2 class="form__message" tabindex="-1" autofocus>
-        <svg aria-hidden="true" focusable="false" role="presentation">
-          <use href="#icon-error" />
-        </svg>
-        {{ 'templates.contact.form.error_heading' | t }}
-      </h2>
-      <ul> 
-        {%- for field in form.errors -%}
-          <li>
-            {%- if field == 'form' -%}
-              {{ form.errors.messages[field] }}
-            {%- else -%}
-              <a href="#RegisterForm-{{ field }}">
-                {{ form.errors.translated_fields[field] | capitalize }}
-                {{ form.errors.messages[field] }}
-              </a>
-            {%- endif -%}
-          </li>
-        {%- endfor -%}
-      </ul>
-    {%- endif -%}
-    <div class="field">      
-      <input
-        type="text"
-        name="customer[first_name]"
-        id="RegisterForm-FirstName"
-        {% if form.first_name %}value="{{ form.first_name }}"{% endif %}
-        autocomplete="given-name"
-        placeholder="{{ 'customer.register.first_name' | t }}"
-      >
-      <label for="RegisterForm-FirstName">
-        {{ 'customer.register.first_name' | t }}
-      </label>
-    </div>
-    <div class="field">
-      <input
-        type="text"
-        name="customer[last_name]"
-        id="RegisterForm-LastName"
-        {% if form.last_name %}value="{{ form.last_name }}"{% endif %}
-        autocomplete="family-name"
-        placeholder="{{ 'customer.register.last_name' | t }}"
-      >
-      <label for="RegisterForm-LastName">
-        {{ 'customer.register.last_name' | t }}
-      </label>
-    </div>
-    <div class="field">      
-      <input
-        type="email"
-        name="customer[email]"
-        id="RegisterForm-email"
-        {% if form.email %} value="{{ form.email }}"{% endif %}
-        spellcheck="false"
-        autocapitalize="off"
-        autocomplete="email"
-        aria-required="true"
-        {% if form.errors contains 'email' %}
-          aria-invalid="true"
-          aria-describedby="RegisterForm-email-error"
-        {% endif %}
-        placeholder="{{ 'customer.register.email' | t }}"
-      >
-      <label for="RegisterForm-email">
-        {{ 'customer.register.email' | t }}
-      </label>
-    </div>
-    {%- if form.errors contains 'email' -%}
-      <span id="RegisterForm-email-error" class="form__message">
-        <svg aria-hidden="true" focusable="false" role="presentation">
-          <use href="#icon-error" />
-        </svg>
-        {{ form.errors.translated_fields['email'] | capitalize }} {{ form.errors.messages['email'] }}.
-      </span>
-    {%- endif -%}
-    <div class="field">     
-      <input
-        type="password"
-        name="customer[password]"
-        id="RegisterForm-password"
-        aria-required="true"
-        {% if form.errors contains 'password' %}
-          aria-invalid="true"
-          aria-describedby="RegisterForm-password-error"
-        {% endif %}
-        placeholder="{{ 'customer.register.password' | t }}"
-      >
-      <label for="RegisterForm-password">
-        {{ 'customer.register.password' | t }}
-      </label>
-    </div>
-    {%- if form.errors contains 'password' -%}
-      <span id="RegisterForm-password-error" class="form__message">
-        <svg aria-hidden="true" focusable="false" role="presentation">
-          <use href="#icon-error" />
-        </svg>
-        {{ form.errors.translated_fields['password'] | capitalize }} {{ form.errors.messages['password'] }}.
-      </span>
-    {%- endif -%}
-    <button>
-      {{ 'customer.register.submit' | t }}
-    </button>
-  {%- endform -%}
-</div>
+	<svg style="display: none">
+		<symbol id="icon-error" viewbox="0 0 13 13">
+			<circle cx="6.5" cy="6.50049" r="5.5" stroke="white" stroke-width="2"/>
+			<circle cx="6.5" cy="6.5" r="5.5" fill="#EB001B" stroke="#EB001B" stroke-width="0.7"/>
+			<path d="M5.87413 3.52832L5.97439 7.57216H7.02713L7.12739 3.52832H5.87413ZM6.50076 9.66091C6.88091 9.66091 7.18169 9.37267 7.18169 9.00504C7.18169 8.63742 6.88091 8.34917 6.50076 8.34917C6.12061 8.34917 5.81982 8.63742 5.81982 9.00504C5.81982 9.37267 6.12061 9.66091 6.50076 9.66091Z" fill="white"/>
+			<path d="M5.87413 3.17832H5.51535L5.52424 3.537L5.6245 7.58083L5.63296 7.92216H5.97439H7.02713H7.36856L7.37702 7.58083L7.47728 3.537L7.48617 3.17832H7.12739H5.87413ZM6.50076 10.0109C7.06121 10.0109 7.5317 9.57872 7.5317 9.00504C7.5317 8.43137 7.06121 7.99918 6.50076 7.99918C5.94031 7.99918 5.46982 8.43137 5.46982 9.00504C5.46982 9.57872 5.94031 10.0109 6.50076 10.0109Z" fill="white" stroke="#EB001B" stroke-width="0.7"></symbol>
+		</svg>
+		<h1>
+			{{ 'customer.register.title' | t }}
+		</h1>
+		{%- form 'create_customer', novalidate: 'novalidate' -%}
+			{%- if form.errors -%}
+				<h2 class="form__message" tabindex="-1" autofocus>
+					<svg aria-hidden="true" focusable="false" role="presentation">
+						<use href="#icon-error"/>
+					</svg>
+					{{ 'templates.contact.form.error_heading' | t }}
+				</h2>
+				<ul>
+					{%- for field in form.errors -%}
+						<li>
+							{%- if field == 'form' -%}
+								{{ form.errors.messages[field] }}
+							{%- else -%}
+								<a href="#RegisterForm-{{ field }}">
+									{{ form.errors.translated_fields[field] | capitalize }}
+									{{ form.errors.messages[field] }}
+								</a>
+							{%- endif -%}
+						</li>
+					{%- endfor -%}
+				</ul>
+			{%- endif -%}
+			<div class="field">
+				<input type="text" name="customer[first_name]" id="RegisterForm-FirstName" {% if form.first_name %} value="{{ form.first_name }}" {% endif %} autocomplete="given-name" placeholder="{{ 'customer.register.first_name' | t }}">
+				<label for="RegisterForm-FirstName">
+					{{ 'customer.register.first_name' | t }}
+				</label>
+			</div>
+			<div class="field">
+				<input type="text" name="customer[last_name]" id="RegisterForm-LastName" {% if form.last_name %} value="{{ form.last_name }}" {% endif %} autocomplete="family-name" placeholder="{{ 'customer.register.last_name' | t }}">
+				<label for="RegisterForm-LastName">
+					{{ 'customer.register.last_name' | t }}
+				</label>
+			</div>
+			<div class="field">
+				<input type="email" name="customer[email]" id="RegisterForm-email" {% if form.email %} value="{{ form.email }}" {% endif %} spellcheck="false" autocapitalize="off" autocomplete="email" aria-required="true" {% if form.errors contains 'email' %} aria-invalid="true" aria-describedby="RegisterForm-email-error" {% endif %} placeholder="{{ 'customer.register.email' | t }}">
+				<label for="RegisterForm-email">
+					{{ 'customer.register.email' | t }}
+				</label>
+			</div>
+			{%- if form.errors contains 'email' -%}
+				<span id="RegisterForm-email-error" class="form__message">
+					<svg aria-hidden="true" focusable="false" role="presentation">
+						<use href="#icon-error"/>
+					</svg>
+					{{ form.errors.translated_fields['email'] | capitalize }}
+					{{ form.errors.messages['email'] }}.
+				</span>
+			{%- endif -%}
+			<div class="field">
+				<input type="password" name="customer[password]" id="RegisterForm-password" aria-required="true" {% if form.errors contains 'password' %} aria-invalid="true" aria-describedby="RegisterForm-password-error" {% endif %} placeholder="{{ 'customer.register.password' | t }}">
+				<label for="RegisterForm-password">
+					{{ 'customer.register.password' | t }}
+				</label>
+			</div>
+			{%- if form.errors contains 'password' -%}
+				<span id="RegisterForm-password-error" class="form__message">
+					<svg aria-hidden="true" focusable="false" role="presentation">
+						<use href="#icon-error"/>
+					</svg>
+					{{ form.errors.translated_fields['password'] | capitalize }}
+					{{ form.errors.messages['password'] }}.
+				</span>
+			{%- endif -%}
+			<div class="accepts-marketing">
+				<input id="accepts-marketing" type="checkbox" name="customer[accepts_marketing]" />
+				<label for="accepts-marketing">{{'customer.register.email_consent' | t }}</label>
+			</div>
+			<button>
+				{{ 'customer.register.submit' | t }}
+			</button>
+		{%- endform -%}
+	</div>


### PR DESCRIPTION
### Goal
- Add a gift wrapping option to the cart
- Add a date picker to the cart for the preferred delivery date
- Added a consent checkbox to the customer registration
- Add a custom meta field for pdf downloads to the PDP

### Testing Instructions
Visit https://zd8qyj4ypsqenl6i-61011132598.shopifypreview.com and confirm that the above goals have been met

### Reviewers
Justin
